### PR TITLE
Fix high CPU usage and needless port forwarding

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
       }
     ]
   },
+  "extensionKind": [
+    "ui"
+  ],
   "icon": "code.png",
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,8 @@ import { ExecuteCommandMessage } from "./messages/executeCommandMessage";
 import { ExtensionConfiguration } from "./configuration";
 import { ActiveSessionChangedMessage } from "./messages/activeSessionChangedMessage";
 import { ChangeLanguageMessage } from "./messages/changeLanguagMessage";
-import { InsertSnippetMessage } from "./messages/InsertSnippetMessage";
-import { OpenFolderMessage } from "./messages/OpenFolderMessage";
+import { InsertSnippetMessage } from "./messages/insertSnippetMessage";
+import { OpenFolderMessage } from "./messages/openFolderMessage";
 
 let extensionController: ExtensionController;
 

--- a/src/extensionController.ts
+++ b/src/extensionController.ts
@@ -10,9 +10,9 @@ import { ExtensionConfiguration } from "./configuration";
 import { ChangeActiveSessionMessage } from "./messages/changeActiveSessionMessage";
 import { Message } from "./messages/message";
 import { ChangeLanguageMessage } from "./messages/changeLanguagMessage";
-import { InsertSnippetMessage } from "./messages/InsertSnippetMessage";
+import { InsertSnippetMessage } from "./messages/insertSnippetMessage";
 import Logger from "./logger";
-import { OpenFolderMessage } from "./messages/OpenFolderMessage";
+import { OpenFolderMessage } from "./messages/openFolderMessage";
 
 export class ExtensionController {
   private hub!: ExtensionHub;

--- a/src/extensionController.ts
+++ b/src/extensionController.ts
@@ -90,11 +90,13 @@ export class ExtensionController {
   }
 
   private onDisconnected() {
-    Logger.log("Disconnected from Stream Deck.");
+    Logger.log("Disconnected from Stream Deck. Reconnecting in 5 seconds.");
 
     this.status.setAsConnecting();
 
-    this.connect();
+    setTimeout(() => {
+      this.connect();
+    }, 5000);
   }
 
   changeActiveSession(sessionId: string) {


### PR DESCRIPTION
This PR fixes some file imports (caused issues on case-sensitive filesystems), creates a 5-second timeout for reconnecting to the Stream Deck software to prevent the busy-loop that caused extreme CPU usage, and designates the extension as a UI extension, putting it on the local extension host when accessing remote environments so it can still access the websocket server without port forwarding.

Fixes #19