### PR TITLE
Restart only when extension configuration updated

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,4 +1,19 @@
+import type * as vscode from "vscode";
+import { Configurations } from "./constants";
+
 export class ExtensionConfiguration {
-  host: string = "127.0.0.1";
-  port: number = 48969;
+  private constructor(public host: string = "127.0.0.1", public port: number = 48969) {}
+
+  public static create(configuration?: vscode.WorkspaceConfiguration): ExtensionConfiguration {
+    return configuration
+      ? new ExtensionConfiguration(
+          configuration.get<string>(Configurations.ServerHost),
+          configuration.get<number>(Configurations.ServerPort)
+        )
+      : new ExtensionConfiguration();
+  }
+
+  public equals(configuration: ExtensionConfiguration) {
+    return this.host === configuration.host && this.port === configuration.port;
+  }
 }


### PR DESCRIPTION
## What I changed

Compare changes of ExtensionConfiguration object and call `extensionController.configurationChanged` only when ExtensionConfiguration is updated.

This change includes a refactor of ExtensionConfiguration.

## Why

VS Code's [ConfigurationChangeEvent](https://code.visualstudio.com/api/references/vscode-api#ConfigurationChangeEvent) is triggered every time when the configuration of workspace updates.

This may cause the unintentional extension restart, for example: `workbench.action.zoomIn` triggers this kind of event and the extension restarts when executed by a button-press.

Restarts of the extension is necessary when the configuration of the extension, thus this change compares a change of ExtensionConfiguration and trigger restarts only when the extension configuration is updated.

## Related issues

fixes https://github.com/nicollasricas/vscode-deck/issues/36
