### PR TITLE
Parse command arguments when not blank

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -123,19 +123,17 @@ function openFolder(request: OpenFolderMessage) {
 
 function executeCommand(request: ExecuteCommandMessage) {
   if (request.command) {
-    let commandArguments;
+    let commandArguments: unknown;
 
-    try {
-      commandArguments = JSON.parse(request.arguments);
-    } catch (error) {
-      Logger.error(error);
+    if (request.arguments.trim() !== "") {
+      try {
+        commandArguments = JSON.parse(request.arguments);
+      } catch (error) {
+        Logger.error(error);
+      }
     }
 
-    if (commandArguments) {
-      vscode.commands.executeCommand(request.command, commandArguments);
-    } else {
-      vscode.commands.executeCommand(request.command);
-    }
+    vscode.commands.executeCommand(request.command, commandArguments);
   }
 }
 


### PR DESCRIPTION
## What I changed

- Parsing of arguments JSON condition in `executeCommand` command
- Call of `executeCommand` function without arguments

## Why

When we set StreamDeck action arguments (JSON) to blank, the payload structure from StreamDeck plugin is like following example:

```
Message received, ExecuteCommandMessage.: {"id":"ExecuteCommandMessage","data":"{\"command\":\"editor.action.formatDocument\",\"arguments\":\"\"}"}
```

This may cause following JSON parse error.

```
Uncaught SyntaxError: Unexpected end of JSON input`
```

This PR fixes this problem.

## Related issues

fixes https://github.com/nicollasricas/vscode-deck/issues/35